### PR TITLE
feat: チェスポーン初期位置マーカー機能を実装

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -25,6 +25,7 @@ function BoardEditorContent() {
   const [isPublic, setIsPublic] = useState(false)
   const [saving, setSaving] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [pawnInitialPositions, setPawnInitialPositions] = useState<Set<string>>(new Set())
 
   const [player1Config, setPlayer1Config] = useState({
     useHandPieces: true,
@@ -102,6 +103,17 @@ function BoardEditorContent() {
             })
           }
         }
+
+        // pawnInitialPositionsを読み込み
+        if (boardData.pawnInitialPositions) {
+          const positions = new Set<string>()
+          boardData.pawnInitialPositions.forEach((pos: { row: number; col: number }) => {
+            positions.add(`${pos.row}-${pos.col}`)
+          })
+          setPawnInitialPositions(positions)
+        } else {
+          setPawnInitialPositions(new Set())
+        }
       }
     } catch (error: any) {
       console.error('Failed to load board:', error)
@@ -166,6 +178,10 @@ function BoardEditorContent() {
         player1: player1PromotionZones,
         player2: player2PromotionZones,
       },
+      pawnInitialPositions: Array.from(pawnInitialPositions).map(key => {
+        const [row, col] = key.split('-').map(Number)
+        return { row, col }
+      }),
     }
     const json = JSON.stringify(data, null, 2)
     const blob = new Blob([json], { type: 'application/json' })
@@ -195,6 +211,10 @@ function BoardEditorContent() {
           player1: player1PromotionZones,
           player2: player2PromotionZones,
         },
+        pawnInitialPositions: Array.from(pawnInitialPositions).map(key => {
+          const [row, col] = key.split('-').map(Number)
+          return { row, col }
+        }),
       }
 
       if (boardId) {
@@ -298,6 +318,17 @@ function BoardEditorContent() {
             shogi: { rows: 3, fromTop: false },
             chess: { rows: 1, fromTop: false },
           })
+        }
+
+        // Load pawnInitialPositions
+        if (data.pawnInitialPositions) {
+          const positions = new Set<string>()
+          data.pawnInitialPositions.forEach((pos) => {
+            positions.add(`${pos.row}-${pos.col}`)
+          })
+          setPawnInitialPositions(positions)
+        } else {
+          setPawnInitialPositions(new Set())
         }
       } catch (error) {
         alert('Failed to import JSON file')
@@ -686,9 +717,14 @@ function BoardEditorContent() {
       {/* Interactive Board Editor */}
       <div className="card">
         <h3 style={{ marginBottom: 'var(--spacing-sm)' }}>Board Editor</h3>
+        <p style={{ fontSize: '14px', color: 'var(--text-muted)', marginBottom: 'var(--spacing-sm)' }}>
+          チェスポーン（CP/cp）をクリックすると、2マス移動可能な初期位置としてマーク/解除できます（青色表示）
+        </p>
         <BoardEditor
           board={board}
           onChange={setBoard}
+          pawnInitialPositions={pawnInitialPositions}
+          onPawnInitialPositionsChange={setPawnInitialPositions}
         />
       </div>
 

--- a/components/Board.tsx
+++ b/components/Board.tsx
@@ -16,6 +16,7 @@ interface BoardProps {
   onPromotionSelect?: (from: Position, to: Position, pieceType: PieceTypeName) => void
   flipped?: boolean  // trueの場合、ボードを180度回転（Player 2用）
   lastMove?: { from: Position | null; to: Position }  // 最後の手
+  initialBoard?: BoardState  // 初期盤面（ポーンの2マス移動判定用）
 }
 
 export default function Board({
@@ -26,7 +27,8 @@ export default function Board({
   dropPositions = [],
   onPromotionSelect,
   flipped = false,
-  lastMove
+  lastMove,
+  initialBoard
 }: BoardProps) {
   const [selectedSquare, setSelectedSquare] = useState<Position | null>(null)
   const [highlightedSquares, setHighlightedSquares] = useState<Position[]>([])
@@ -72,7 +74,7 @@ export default function Board({
       // 自分の別の駒をクリックした場合 = 選択変更
       if (piece && piece.player === currentPlayer) {
         setSelectedSquare(clickedPos)
-        const moves = getLegalMoves(board, clickedPos, piece)
+        const moves = getLegalMoves(board, clickedPos, piece, initialBoard)
         setHighlightedSquares(moves)
         return
       }
@@ -84,7 +86,7 @@ export default function Board({
       // 何も選択していない状態で自分の駒をクリック = 選択
       // onMoveが有効な場合のみ選択可能
       setSelectedSquare(clickedPos)
-      const moves = getLegalMoves(board, clickedPos, piece)
+      const moves = getLegalMoves(board, clickedPos, piece, initialBoard)
       setHighlightedSquares(moves)
     }
   }

--- a/lib/ai/aiService.ts
+++ b/lib/ai/aiService.ts
@@ -134,9 +134,9 @@ export class AIService {
   /**
    * Get best move for current board state
    */
-  async getBestMove(board: BoardState, player: Player): Promise<Move | null> {
+  async getBestMove(board: BoardState, player: Player, initialBoard?: BoardState): Promise<Move | null> {
     if (this.config.type === 'simple' || !this.worker) {
-      return getSimpleBestMove(board, player, this.config.difficulty || 'medium');
+      return getSimpleBestMove(board, player, this.config.difficulty || 'medium', initialBoard);
     }
 
     return new Promise((resolve) => {

--- a/lib/ai/simpleAI.ts
+++ b/lib/ai/simpleAI.ts
@@ -48,7 +48,7 @@ function evaluateBoard(board: BoardState, player: Player): number {
 }
 
 // 可能な全ての手を生成（legalMoves.tsのgetLegalMovesを使用）
-function generateMoves(board: BoardState, player: Player): Move[] {
+function generateMoves(board: BoardState, player: Player, initialBoard?: BoardState): Move[] {
   const moves: Move[] = []
   const boardSize = board.length
 
@@ -58,7 +58,7 @@ function generateMoves(board: BoardState, player: Player): Move[] {
       if (piece && piece.player === player) {
         const from: Position = { row, col }
         // 修正: getPossibleMoves → getLegalMoves に変更して王手チェックを行う
-        const legalMoves = getLegalMoves(board, from, piece)
+        const legalMoves = getLegalMoves(board, from, piece, initialBoard)
 
         for (const to of legalMoves) {
           const targetPiece = board[to.row][to.col]
@@ -95,14 +95,15 @@ function minimax(
   maximizingPlayer: boolean,
   player: Player,
   alpha: number = -Infinity,
-  beta: number = Infinity
+  beta: number = Infinity,
+  initialBoard?: BoardState
 ): number {
   if (depth === 0) {
     return evaluateBoard(board, player)
   }
 
   const currentPlayer: Player = maximizingPlayer ? player : (player === 1 ? 2 : 1)
-  const moves = generateMoves(board, currentPlayer)
+  const moves = generateMoves(board, currentPlayer, initialBoard)
 
   if (moves.length === 0) {
     return evaluateBoard(board, player)
@@ -112,7 +113,7 @@ function minimax(
     let maxEval = -Infinity
     for (const move of moves) {
       const newBoard = applyMove(board, move)
-      const evalScore = minimax(newBoard, depth - 1, false, player, alpha, beta)
+      const evalScore = minimax(newBoard, depth - 1, false, player, alpha, beta, initialBoard)
       maxEval = Math.max(maxEval, evalScore)
       alpha = Math.max(alpha, evalScore)
       if (beta <= alpha) break // Alpha-beta pruning
@@ -122,7 +123,7 @@ function minimax(
     let minEval = Infinity
     for (const move of moves) {
       const newBoard = applyMove(board, move)
-      const evalScore = minimax(newBoard, depth - 1, true, player, alpha, beta)
+      const evalScore = minimax(newBoard, depth - 1, true, player, alpha, beta, initialBoard)
       minEval = Math.min(minEval, evalScore)
       beta = Math.min(beta, evalScore)
       if (beta <= alpha) break // Alpha-beta pruning
@@ -132,9 +133,9 @@ function minimax(
 }
 
 // AIが最善手を選択
-export function getBestMove(board: BoardState, player: Player, difficulty: 'easy' | 'medium' | 'hard' = 'medium'): Move | null {
+export function getBestMove(board: BoardState, player: Player, difficulty: 'easy' | 'medium' | 'hard' = 'medium', initialBoard?: BoardState): Move | null {
   const depth = difficulty === 'easy' ? 1 : difficulty === 'medium' ? 2 : 3
-  const moves = generateMoves(board, player)
+  const moves = generateMoves(board, player, initialBoard)
 
   if (moves.length === 0) return null
 
@@ -148,7 +149,7 @@ export function getBestMove(board: BoardState, player: Player, difficulty: 'easy
 
   for (const move of moves) {
     const newBoard = applyMove(board, move)
-    const moveValue = minimax(newBoard, depth - 1, false, player)
+    const moveValue = minimax(newBoard, depth - 1, false, player, -Infinity, Infinity, initialBoard)
 
     if (moveValue > bestValue) {
       bestValue = moveValue
@@ -160,8 +161,8 @@ export function getBestMove(board: BoardState, player: Player, difficulty: 'easy
 }
 
 // ランダムな手を選択（最も簡単なAI）
-export function getRandomMove(board: BoardState, player: Player): Move | null {
-  const moves = generateMoves(board, player)
+export function getRandomMove(board: BoardState, player: Player, initialBoard?: BoardState): Move | null {
+  const moves = generateMoves(board, player, initialBoard)
   if (moves.length === 0) return null
   return moves[Math.floor(Math.random() * moves.length)]
 }

--- a/lib/board/types.ts
+++ b/lib/board/types.ts
@@ -9,6 +9,7 @@ export interface CustomBoardData {
     player1: PromotionZoneConfig | PieceTypePromotionZones  // Single or piece-type-specific
     player2: PromotionZoneConfig | PieceTypePromotionZones
   }
+  pawnInitialPositions?: { row: number; col: number }[]  // Chess pawns that can move 2 squares initially
 }
 
 export interface PlayerConfig {

--- a/lib/game/board.ts
+++ b/lib/game/board.ts
@@ -183,7 +183,8 @@ export function isValidPosition(pos: Position, boardSize: number = 9): boolean {
 export function getPossibleMoves(
   board: BoardState,
   pos: Position,
-  piece: Piece
+  piece: Piece,
+  initialBoard?: BoardState
 ): Position[] {
   const moves: Position[] = []
   const boardSize = board.length
@@ -313,8 +314,21 @@ export function getPossibleMoves(
 
     case 'chess_pawn': // チェスのポーン
       // 前方1マス（まだ動いていない場合は2マス）
-      const startRow = player === 1 ? 6 : 1
       const newRow = pos.row + direction
+
+      // 初期位置判定: initialBoardがあればそれを使用、なければデフォルト
+      let isAtStartingPosition = false
+      if (initialBoard) {
+        // カスタムボード: 初期位置と現在位置が一致するかチェック
+        const initialPiece = initialBoard[pos.row]?.[pos.col]
+        isAtStartingPosition =
+          initialPiece?.type === 'chess_pawn' &&
+          initialPiece?.player === player
+      } else {
+        // 通常ボード: 固定行数
+        const startRow = player === 1 ? 6 : 1
+        isAtStartingPosition = pos.row === startRow
+      }
 
       // 前方1マス（駒がない場合のみ）
       if (isValidPosition({ row: newRow, col: pos.col }, boardSize)) {
@@ -325,7 +339,7 @@ export function getPossibleMoves(
       }
 
       // 初期位置から2マス
-      if (pos.row === startRow) {
+      if (isAtStartingPosition) {
         const twoRow = pos.row + direction * 2
         if (isValidPosition({ row: twoRow, col: pos.col }, boardSize)) {
           const middle = board[pos.row + direction][pos.col]

--- a/lib/game/legalMoves.ts
+++ b/lib/game/legalMoves.ts
@@ -9,10 +9,11 @@ import { isInCheck } from './checkmate'
 export function getLegalMoves(
   board: BoardState,
   from: Position,
-  piece: Piece
+  piece: Piece,
+  initialBoard?: BoardState
 ): Position[] {
   // まず全ての可能な手を取得
-  const possibleMoves = getPossibleMoves(board, from, piece)
+  const possibleMoves = getPossibleMoves(board, from, piece, initialBoard)
 
   // 各手について、その手が自分の王を危険にさらさないかチェック
   const legalMoves = possibleMoves.filter(to => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,6 +56,7 @@ export interface GameState {
     player2: PieceTypePromotionZones;
   };
   lastMove?: Move; // 最後に指された手（ハイライト表示用）
+  initialBoard?: BoardState; // 初期盤面（カスタムボードのポーン判定用）
 }
 
 // 盤の種類


### PR DESCRIPTION
カスタムボードエディターでチェスポーンの2マス移動可能な初期位置を
視覚的にマーキングできる機能を追加
主な変更点:
- ポーンクリックで青色マーカーをトグル
- pawnInitialPositions配列による初期位置管理
- initialBoardを使用したカスタム初期位置判定
- AI処理でもinitialBoard参照に対応
- executeMove/handleDropでのinitialBoard保持を修正 影響ファイル: 10ファイル
- lib/board/types.ts, lib/types.ts
- components/BoardEditor.tsx, Board.tsx
- app/editor/page.tsx, app/local/[mode]/[boardType]/page.tsx
- lib/game/board.ts, legalMoves.ts
- lib/ai/simpleAI.ts, aiService.ts

close: #26 